### PR TITLE
fix(versions): update Activiti/activiti-cloud-infrastructure-chart versions

### DIFF
--- a/charts/infrastructure/requirements.yaml
+++ b/charts/infrastructure/requirements.yaml
@@ -6,5 +6,5 @@ dependencies:
   condition: "infrastructure.activiti-keycloak.enabled,activiti-keycloak.enabled"
 - name: "activiti-cloud-gateway"
   repository: "https://activiti.github.io/activiti-cloud-helm-charts/"
-  version: "1.0.5"
+  version: "1.0.6"
   condition: "infrastructure.activiti-cloud-gateway.enabled,activiti-cloud-gateway.enabled"


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed helm dependency: `activiti-cloud-gateway` to: `1.0.6`